### PR TITLE
Minor code cleanup 

### DIFF
--- a/src/assist.c
+++ b/src/assist.c
@@ -327,7 +327,7 @@ void assist_additional_forces(struct reb_simulation* sim){
     int N_ephem, N_ast;
     int number_bodies(int* N_ephem, int* N_ast);
 
-    const int N_tot = number_bodies(&N_ephem, &N_ast);    
+    number_bodies(&N_ephem, &N_ast);    
 
     // The limit of the EIH GR limit should be a free
     // parameter
@@ -728,7 +728,6 @@ void store_function(struct reb_simulation* sim){
 
     outtime = ts->t;
     outstate = ts->state;
-    int n_alloc= ts->n_alloc;
 
     if(step==0){
 
@@ -874,10 +873,6 @@ void store_coefficients(struct reb_simulation* sim){
 
     static int last_steps_done = 0;
 
-    double s[9]; // Summation coefficients
-
-    struct assist_extras* assist = (struct assist_extras*) sim->extras;
-
     //int nsubsteps = assist->nsubsteps;
     //double* hg = assist->hg;
 
@@ -900,10 +895,6 @@ void store_coefficients(struct reb_simulation* sim){
 	//printf("initial step %d %lf\n", step, sim->t);
 	
     }else if(step > last_steps_done){
-
-	// Convenience variable.  The 'br' field contains the 
-	// set of coefficients from the last completed step.
-	const struct reb_dpconst7 b  = dpcast(sim->ri_ias15.br);
 
 	double* x0 = malloc(sizeof(double)*N3);
 	double* v0 = malloc(sizeof(double)*N3);
@@ -1003,7 +994,7 @@ void direct(struct reb_simulation* sim, double xo, double yo, double zo, FILE *o
     double GM;
     double x, y, z, vx, vy, vz, ax, ay, az;
 
-    static const order[] = {26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
+    static const int order[] = {26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
 			    16, 15, 14, 13, 12, 11, 10, 9, 8, 5, 4, 
 			    1, 2, 7, 6, 3, 0};
 
@@ -1467,7 +1458,6 @@ void non_gravs(struct reb_simulation* sim,
 
     const unsigned int N = sim->N;  // N includes real+variational particles
     const unsigned int N_real = N - sim->N_var;
-    const unsigned int N_var = sim->N_var;  // N includes real+variational particles    
 
     const double t = sim->t;    
 
@@ -1896,7 +1886,6 @@ void eih_GR(struct reb_simulation* sim,
     // The Sun center is reference for these calculations.
     double xs, ys, zs, vxs, vys, vzs, axs, ays, azs;
     all_ephem(0, t, &GM, &xs, &ys, &zs, &vxs, &vys, &vzs, &axs, &ays, &azs);
-    const double GMsun = GM;    
 
     xr  = xs;  yr  = ys;  zr = zs;
     vxr = vxs; vyr = vys; vzr = vzs;
@@ -1905,7 +1894,7 @@ void eih_GR(struct reb_simulation* sim,
     int N_ephem, N_ast;
     int number_bodies(int* N_ephem, int* N_ast);
 
-    const int N_tot = number_bodies(&N_ephem, &N_ast);
+    number_bodies(&N_ephem, &N_ast);
 
     double beta = 1.0;
     double gamma = 1.0;

--- a/src/spk.c
+++ b/src/spk.c
@@ -73,14 +73,14 @@ static int _com(const char *buf)
 }
 
 // display output strings to console
-static void _sho(const char *buf)
-{
-	int n, p;
-
-	// this doesn't always handle the newlines correctly
-	for (n = 0; buf[n+1] != '\0';)
-		n += fprintf(stdout, "%s\n", &buf[n]) - 1;
-}
+//static void _sho(const char *buf)
+//{
+//	int n;
+//
+//	// this doesn't always handle the newlines correctly
+//	for (n = 0; buf[n+1] != '\0';)
+//		n += fprintf(stdout, "%s\n", &buf[n]) - 1;
+//}
 
 struct spk_s * spk_init(const char *path)
 {
@@ -92,7 +92,6 @@ struct spk_s * spk_init(const char *path)
 	int fd, nd, ni, nc;
 	int m, n, c, b, B;
 	off_t off;
-	int num;
 
 	if ((fd = open(path, O_RDONLY)) < 0)
 		return NULL;
@@ -229,7 +228,6 @@ int spk_find(struct spk_s *pl, int tar)
 
 int spk_calc(struct spk_s *pl, int m, double jde, double rel, struct mpos_s *pos)
 {
-	struct sum_s *sum;
 	int n, b, p, P, R;
 	double T[32], S[32];
 	double *val, z;
@@ -246,7 +244,7 @@ int spk_calc(struct spk_s *pl, int m, double jde, double rel, struct mpos_s *pos
 
 	// find location of 'directory' describing the data records
 	n = (int)((jde + rel - pl->beg[m]) / pl->res[m]);
-	val = pl->map + sizeof(double) * (pl->two[m][n] - 1);
+	val = (double*)pl->map + sizeof(double) * (pl->two[m][n] - 1);
 
 	// record size and number of coefficients per coordinate
 	R = (int)val[-1];
@@ -254,7 +252,7 @@ int spk_calc(struct spk_s *pl, int m, double jde, double rel, struct mpos_s *pos
 
 	// pick out the precise record
 	b = (int)(((jde - _jul(val[-3])) + rel) / (val[-2] / 86400.0));
-	val = pl->map + sizeof(double) * (pl->one[m][n] - 1)
+	val = (double*)pl->map + sizeof(double) * (pl->one[m][n] - 1)
 			+ sizeof(double) * b * R;
 
 	// scale to interpolation units


### PR DESCRIPTION
Mainly to suppress warning messages on clang:

- removed unused variables
- cleaned up pointer arithmetic
- commented out unused static function