### PR TITLE
Make sure librebound is compiled before libassist is started.

### DIFF
--- a/examples/simplest/Makefile
+++ b/examples/simplest/Makefile
@@ -29,7 +29,7 @@ librebound.so:
 	@-rm -f librebound.so
 	@ln -s $(REB_DIR)/src/librebound.so .
 
-libassist.so: 
+libassist.so: librebound.so 
 	@echo "Compiling shared library libassist.so ..."
 	$(MAKE) -C $(ASSIST_DIR)/src/
 	@-rm -f libassist.so


### PR DESCRIPTION
Super minor change. But this way one can run make in parallel with 

``make clean && make -j``