### PR TITLE
Added unit test framework for github CI

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -1,0 +1,40 @@
+name: ASSIST Unit Tests (C)
+
+on: [push, pull_request]
+
+env:
+  JPL_PLANET_EPHEM: ../../data/linux_p1550p2650.440
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download REBOUND
+        working-directory: ../
+        run: | 
+          pwd
+          git clone https://github.com/hannorein/rebound.git
+          #- name: Compile REBOUND
+          #  working-directory: ../rebound
+          #  run: | 
+          #    pwd
+          #    make
+          #- name: Compile ASSIST
+          #  run: | 
+          #    make
+      - name: Download DE441 dataset
+        working-directory: ./data/
+        run: |
+          #wget --no-verbose https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de441/linux_m13000p17000.441  
+          wget --no-verbose https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de440/linux_p1550p2650.440
+          wget --no-verbose https://ssd.jpl.nasa.gov/ftp/eph/small_bodies/asteroids_de441/sb441-n16.bsp
+      - name: Reproduce Holman trajectory
+        working-directory: ./unit_tests/holman/
+        run: |
+          make
+          ls -lsa 
+          #cp ../../../rebound/src/librebound.so .
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound

--- a/src/forces.c
+++ b/src/forces.c
@@ -171,9 +171,9 @@ void assist_additional_forces(struct reb_simulation* sim){
 	first=1;
     }
 
-    fclose(eih_file);
-    fflush(outfile);
-    fclose(outfile);
+    //fclose(eih_file);
+    //fflush(outfile);
+    //fclose(outfile);
 
     if(geo == 1){
 	// geocentric

--- a/unit_tests/holman/Makefile
+++ b/unit_tests/holman/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so 
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/holman/problem.c
+++ b/unit_tests/holman/problem.c
@@ -1,0 +1,74 @@
+/**
+ * This example demonstrates how to use ASSIST to integrate a test particle in 
+ * the field of the Sun, planets, moon, and a set of massive asteroids, whose
+ * positions come from JPL's DE440/441 ephemeris.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "rebound.h"
+#include "assist.h"
+
+int main(int argc, char* argv[]){
+    // Initial conditions of asteroid
+    int n_particles = 1;    
+    double* state = malloc(n_particles*6*sizeof(double));
+    state[0] = 3.3388753502614090e+00;  // x in AU
+    state[1] = -9.1765182678903168e-01; // y
+    state[2] = -5.0385906775843303e-01; // z
+    state[3] = 2.8056633153049852e-03;  // vx in AU/day
+    state[4] = 7.5504086883996860e-03;  // vy
+    state[5] = 2.9800282074358684e-03;  // vz
+   
+    double jd_ref = 2451545.0;  // All times are emasured relative to this Julian date 
+    double tstart = 7304.5;     // Initial time 
+    double tend = 7404.5;       // Final time
+    double tstep = 20;          // Integration step size. 
+    
+    
+    // Interpolate between integration steps on these substeps 
+    int n_substeps = 4;
+    double hg[n_substeps+1];
+    for(int i=0; i<=n_substeps; i++){
+        hg[i]=(1.0/n_substeps)*i;
+    }
+
+    // Allocate memory for output.
+    int n_alloc = ((tend-tstart)/tstep + 1)*n_substeps;
+    double* outstate = (double *) malloc((n_alloc)*6*sizeof(double));
+    double* outtime  = (double *) malloc((n_alloc)*sizeof(double));
+
+    int n_steps_done;
+    int status = integration_function(
+            jd_ref,                 // I do not understand what this variable does
+            tstart, tend, tstep,    // Time range of integration 
+            0,                      // 1=geocentric, 0=barycentric
+            1e-9,                   // epsilon
+            n_particles,            // number of particles
+            state,                  // initial conditions
+            NULL,                   // additional particle parameters for non-gravitational effects (not used in this example)
+            0, NULL, NULL, NULL,    // No variational particles in this example
+            n_alloc,                // Allocated space in output array
+            &n_steps_done,          // Number of steps actually done
+            n_substeps,             // Number of substeps 
+            hg,                     // Location of substeps (in fractions of an integration time step)
+            outtime,                // Output times
+            outstate,               // Output states
+            0.0                     // Minimum dt in integration
+            ); 
+    if (status != REB_EXIT_SUCCESS) {
+       printf("Warning! Simulation did *not* run successfully.\n");
+    } 
+
+    // Number of outputs generated
+    int n_outs = n_steps_done*n_substeps + 1;
+    
+    // Check final time
+    assert(outtime[n_outs-1] == tend);
+
+    // Check x position. 
+    int offset = (n_outs-1)*6;
+    printf("%.20f\n", outstate[offset]);
+    assert(outstate[offset+0] == 3.50261534999964929682); // Note: this value is just a dummy. Hard code JPL values here.
+}
+


### PR DESCRIPTION
One thing I learned when working on REBOUND is that unit tests really help a lot in the long run. More than once I've changed something what I thought is trivial, but it ended up breaking all kind of things. 

This pull requests adds a GitHub workflow which can run unit tests automatically whenever someone pushes a commit or opens a pull request. Right now there is just a trivial check in `unit_tests/holman/` that compares the final x position of a short integration to what I get on my computer. We should add a couple of these test where we compare integrations to actual JPL output and require that they are identical to within some accuracy. 

The workflow is downloading the DE440 and small body database from the JPL server every time. Although these are large files, it only takes a few seconds. I hope JPL doesn't mind. 