### PR TITLE
Cleanup

### DIFF
--- a/examples/asteroid/Makefile
+++ b/examples/asteroid/Makefile
@@ -29,7 +29,7 @@ librebound.so:
 	@-rm -f librebound.so
 	@ln -s $(REB_DIR)/src/librebound.so .
 
-libassist.so: librebound.so 
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c 
 	@echo "Compiling shared library libassist.so ..."
 	$(MAKE) -C $(ASSIST_DIR)/src/
 	@-rm -f libassist.so

--- a/examples/asteroid/problem.c
+++ b/examples/asteroid/problem.c
@@ -19,11 +19,11 @@ int main(int argc, char* argv[]){
     state[4] = 7.5504086883996860e-03;  // vy
     state[5] = 2.9800282074358684e-03;  // vz
    
-    double tstart = 2458849.5; // Initial time 
-    double tend = 2458949.5;   // Final time
-    double tstep = 20;         // Integration step size. 
+    double jd_ref = 2451545.0;  // Reference date in JD
+    double tstart = 7304.5;     // Initial time relative to jd_ref
+    double tend = 7404.5;       // Final time relative to jd_ref
+    double tstep = 20;          // Integration step size. 
     
-    double jd_ref = 2451545.0; // I do not understand what this variable does
     
     // Interpolate between integration steps on these substeps 
     int n_substeps = 4;

--- a/examples/simplest/Makefile
+++ b/examples/simplest/Makefile
@@ -29,7 +29,7 @@ librebound.so:
 	@-rm -f librebound.so
 	@ln -s $(REB_DIR)/src/librebound.so .
 
-libassist.so: librebound.so 
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c 
 	@echo "Compiling shared library libassist.so ..."
 	$(MAKE) -C $(ASSIST_DIR)/src/
 	@-rm -f libassist.so

--- a/examples/simplest/holman_ic
+++ b/examples/simplest/holman_ic
@@ -1,5 +1,5 @@
-tstart 2458849.5
-tepoch 2458849.5
+tstart 7304.5
+tepoch 7404.5
 tend   2458949.5
 tstep 20.0
 geocentric 0

--- a/src/assist.c
+++ b/src/assist.c
@@ -212,7 +212,6 @@ int integration_function(double jd_ref,
     // and initialize some values.
     struct assist_extras* assist = assist_attach(sim);
     assist->particle_params = NULL;
-    assist->N = 0;
     assist->geocentric = geocentric;
     assist->jd_ref = jd_ref; // 2451545.0; 
 
@@ -236,10 +235,11 @@ int integration_function(double jd_ref,
 	// needs to be a set of extra parameters.
 	// The number of non-grav parameters should be flexible,
 	// rather than fixed at 3.	
-	assist->N++;
+
+    int N = sim->N;
 	// If part_params is NULL, skip this part
 	if(part_params != NULL){
-	    assist->particle_params = realloc(assist->particle_params, (assist->N)*3*sizeof(double));
+	    assist->particle_params = realloc(assist->particle_params, N*3*sizeof(double));
 	    assist->particle_params[3*i+0] = part_params[3*i+0];
 	    assist->particle_params[3*i+1] = part_params[3*i+1];
 	    assist->particle_params[3*i+2] = part_params[3*i+2];
@@ -272,10 +272,10 @@ int integration_function(double jd_ref,
 	// needs to be a set of extra parameters.
 	// The number of non-grav parameters should be flexible,
 	// rather than fixed at 3.	
-	assist->N++;
+    int N = sim->N;
 	// If var_part_params is null, skip this part.
 	if(var_part_params != NULL){	
-	    assist->particle_params = realloc(assist->particle_params, (assist->N)*3*sizeof(double));
+	    assist->particle_params = realloc(assist->particle_params, N*3*sizeof(double));
 	    assist->particle_params[3*var_i+0] = var_part_params[3*i+0];
 	    assist->particle_params[3*var_i+1] = var_part_params[3*i+1];
 	    assist->particle_params[3*var_i+2] = var_part_params[3*i+2];

--- a/src/assist.h
+++ b/src/assist.h
@@ -65,7 +65,6 @@ typedef struct {
 
 struct assist_extras {
     struct reb_simulation* sim;
-    double* c;
     int geocentric;
     tstate* last_state;
     timestate* ts;

--- a/src/assist.h
+++ b/src/assist.h
@@ -72,7 +72,6 @@ struct assist_extras {
     double* hg;
     //particle_params* particle_params;
     double* particle_params;
-    int N;
     double jd_ref;
 };
 


### PR DESCRIPTION
A few minor things:
- Fixed the `jd_ref` in the example
- Removes the `N` variable from `assist_extras`. This is not needed. `sim->N` can be used instead. 
- Changed the Makefile so that one can simply type `make` in the example directories and it will recompile ASSIST if a source file has changed.