### PR TITLE
Refactoring the assist_jpl_calc function

### DIFF
--- a/src/assist.c
+++ b/src/assist.c
@@ -348,12 +348,12 @@ static void store_function(struct reb_simulation* sim){
     int N = sim->N;
     int N3 = 3*N;
 
-    static int last_steps_done = 0;
 
     double s[9]; // Summation coefficients
 
     struct assist_extras* assist = (struct assist_extras*) sim->extras;
 
+    int steps_done = assist->steps_done;
     int nsubsteps = assist->nsubsteps;
     double* hg = assist->hg;
 
@@ -380,7 +380,7 @@ static void store_function(struct reb_simulation* sim){
             output_state[state_offset++] = sim->particles[j].vz;
         }
 
-    }else if(sim->steps_done > last_steps_done){
+    }else if(sim->steps_done > steps_done){
 
         // Convenience variable.  The 'br' field contains the 
         // set of coefficients from the last completed step.
@@ -492,7 +492,7 @@ static void store_function(struct reb_simulation* sim){
         free(v0);
         free(a0);
     }
-    last_steps_done = sim->steps_done;
+    steps_done = sim->steps_done;
 
     if((assist->output_n_alloc-step*nsubsteps) < 1){
         sim->status = REB_EXIT_USER;

--- a/src/assist.h
+++ b/src/assist.h
@@ -66,6 +66,7 @@ struct assist_extras {
     double* output_t; 
     double* output_state;
     int output_n_alloc;
+    int steps_done;
     double jd_ref;
 };
 

--- a/src/forces.c
+++ b/src/forces.c
@@ -247,21 +247,7 @@ static int ephem(const int i, const double jd_ref, const double t,
 
     *GM = JPL_GM[i];
 
-    static const int ebody[11] = {
-        PLAN_SOL,                       // Sun (in barycentric)
-        PLAN_MER,                       // Mercury center
-        PLAN_VEN,                       // Venus center
-        PLAN_EAR,                       // Earth center
-        PLAN_LUN,                       // Moon center
-        PLAN_MAR,                       // Mars center
-        PLAN_JUP,                       // ...
-        PLAN_SAT,
-        PLAN_URA,
-        PLAN_NEP,
-        PLAN_PLU
-    };
-
-    assist_jpl_calc(pl, &now, jd_ref, t, ebody[i], PLAN_BAR);
+    assist_jpl_calc(pl, &now, jd_ref, t, i); 
 
     // Convert to au/day and au/day^2
     vecpos_div(now.u, pl->cau);

--- a/src/planets.h
+++ b/src/planets.h
@@ -8,27 +8,6 @@ void assist_jpl_work(double *P, int ncm, int ncf, int niv, double t0, double t1,
 int assist_jpl_calc(struct _jpl_s *pl, struct mpos_s *pos, double jd_ref, double jd_rel, int body);
 double assist_jpl_mass(struct _jpl_s *pl, int tar);
 
-// these are the body codes for the user to specify
-enum {
-        PLAN_BAR,                       // <0,0,0>
-        PLAN_SOL,                       // Sun (in barycentric)
-        PLAN_EAR,                       // Earth centre
-        PLAN_EMB,                       // Earth-Moon barycentre
-        PLAN_LUN,                       // Moon centre
-        PLAN_MER,                       // ... plus the rest
-        PLAN_VEN,
-        PLAN_MAR,
-        PLAN_JUP,
-        PLAN_SAT,
-        PLAN_URA,
-        PLAN_NEP,
-        PLAN_PLU,	
-
-        _NUM_TEST,
-};
-
-//int body[11];
-
 #define N_COMPONENTS_JPL 15
 struct _jpl_s {
         double beg, end;                // begin and end times

--- a/src/planets.h
+++ b/src/planets.h
@@ -5,7 +5,7 @@
 struct _jpl_s * assist_jpl_init(void);
 int assist_jpl_free(struct _jpl_s *jpl);
 void assist_jpl_work(double *P, int ncm, int ncf, int niv, double t0, double t1, double *u, double *v, double *w);
-int assist_jpl_calc(struct _jpl_s *jpl, struct mpos_s *now, double jde, double rel, int n, int m);
+int assist_jpl_calc(struct _jpl_s *pl, struct mpos_s *pos, double jd_ref, double jd_rel, int body);
 double assist_jpl_mass(struct _jpl_s *pl, int tar);
 
 // these are the body codes for the user to specify
@@ -29,27 +29,7 @@ enum {
 
 //int body[11];
 
-// these are array indices for the internal interface
-enum {
-        JPL_MER,                        // Mercury
-        JPL_VEN,                        // Venus
-        JPL_EMB,                        // Earth
-        JPL_MAR,                        // Mars
-        JPL_JUP,                        // Jupiter
-        JPL_SAT,                        // Saturn
-        JPL_URA,                        // Uranus
-        JPL_NEP,                        // Neptune
-        JPL_PLU,                        // Pluto
-        JPL_LUN,                        // Moon (geocentric)
-        JPL_SUN,                        // the Sun
-        JPL_NUT,                        // nutations
-        JPL_LIB,                        // lunar librations
-        JPL_MAN,                        // lunar mantle
-        JPL_TDB,                        // TT-TDB (< 2 ms)
-
-        _NUM_JPL,
-};
-
+#define N_COMPONENTS_JPL 15
 struct _jpl_s {
         double beg, end;                // begin and end times
         double inc;                     // time step size
@@ -57,10 +37,10 @@ struct _jpl_s {
         double cem;                     // Earth/Moon mass ratio
         int32_t num;                    // number of constants
         int32_t ver;                    // ephemeris version
-        int32_t off[_NUM_JPL];          // indexing offset
-        int32_t ncf[_NUM_JPL];          // number of chebyshev coefficients
-        int32_t niv[_NUM_JPL];          // number of interpolation intervals
-        int32_t ncm[_NUM_JPL];          // number of components / dimension
+        int32_t off[N_COMPONENTS_JPL];                // indexing offset
+        int32_t ncf[N_COMPONENTS_JPL];                // number of chebyshev coefficients
+        int32_t niv[N_COMPONENTS_JPL];                // number of interpolation intervals
+        int32_t ncm[N_COMPONENTS_JPL];                // number of components / dimension
 ///
         size_t len, rec;                // file and record sizes
         void *map;                      // memory mapped location


### PR DESCRIPTION
(This pull requests builds on the plain interface one, you might want to merge in that one before this one)

I've refactored the `assist_jpl_calc` function because I've had a really hard time following what was going on.

In particular it took me a while to work my way through the various particle indices. Originally the situation was as follows: the `ephem` function loops over `0, 1, 2, ..`. It then used the `ebody` static array to map those indices to another set of indices. The `ebody` array itself contained constants such as `PLAN_SOL`, `PLAN_MER`,..  which were defined as an enum in planets.h. Then in `assist_jpl_calc` there was a function pointer lookup table which mapped those indices yet again to a set of static (mostly one-line) functions. So in the end, there were four (!) steps involved in mapping the indices `0, 1, 2,...` to the corresponding columns in the JPL file (plus some extra logic for the Earth and Moon). 

I don't know the full history and I'm sure there were good reasons for doing it the way it was. However, I've now changed it so that there is only one mapping, and it's in `assist_jpl_calc` itself in the form of one simple switch statement. I got rid of the `ebody` array, the `PLAN_...` enum, the `JPL_...` enum, and the `_help[]` function pointer lookup table. 

In addition, I've also:
- Named variables in the function `jd_ref` and `jd_rel` to better indicate what they are.
- Originally the function had two particle indices, but the second one was always set to the index corresponding to the barycentre. Now there is only one particle index.
- The function now directly works on its argument `pos` so we don't have to copy the data anymore.
- I moved the previously static `steps_done` variable in `assist.c` into the `assist_struct`. That's important for eventually making it thread safe (there are a couple of other instances where we'll need to remove a static variable). 

All in all, this pull request reduces the number of line in the code by 75 and should hopefully make it easier to read and maintain. The ephemeris results remain unchanged and it doesn't break any example cod. But please let me know if I'm missing something or if I'm breaking some future work you might have planned. 

