### PR TITLE
Memory management

### DIFF
--- a/examples/simplest/problem.c
+++ b/examples/simplest/problem.c
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]){
 
     printf("entering integration_function\n");
     int n_steps;
-    int status = integration_function(jd_ref,
+    int status = assist_integrate(jd_ref,
 				      tstart, tend, tstep, 0, 1e-9,
 				      n_particles, instate,
 				      part_paramst,

--- a/src/assist.c
+++ b/src/assist.c
@@ -457,13 +457,13 @@ static void assist_heartbeat(struct reb_simulation* sim){
 
     }else if(sim->steps_done > steps_done){
 
-        int time_offset = (step-1)*nsubsteps+1;
         double* hg = assist->hg;
 
         // Loop over substeps
         for(int n=1;n<(nsubsteps+1);n++) {	    
-            output_t[time_offset] = sim->t + sim->dt_last_done * (-1.0 + hg[n]);
-            assist_interpolate(sim, hg[n], output_state +  ((step-1)*nsubsteps + n)*6*N ); 
+            int offset = (step-1)*nsubsteps;
+            output_t[offset+n] = sim->t + sim->dt_last_done * (-1.0 + hg[n]);
+            assist_interpolate(sim, hg[n], output_state +  (offset + n)*6*N );
         }
     }
     steps_done = sim->steps_done;

--- a/src/assist.h
+++ b/src/assist.h
@@ -73,7 +73,10 @@ enum ASSIST_FORCES {
 struct assist_extras {
     struct reb_simulation* sim;
     int geocentric;
-    tstate* last_state;
+    double last_state_t;
+    double* last_state_x;
+    double* last_state_v;
+    double* last_state_a;
     int nsubsteps;
     double* hg;
     //particle_params* particle_params;

--- a/src/assist.h
+++ b/src/assist.h
@@ -41,15 +41,6 @@ extern const char* assist_version_str;    ///< Version string.
 extern const char* assist_githash_str;    ///< Current git hash.
 
 typedef struct {
-  double t, x, y, z, vx, vy, vz, ax, ay, az;
-} tstate;
-
-typedef struct {
-    double t;
-    tstate* tstates;
-} ephem_block;
-
-typedef struct {
     double A1;
     double A2;
     double A3;        


### PR DESCRIPTION
This pull request removes the `tstate` struct which was used as a type for `last_state`. The same data is now just stored in three arrays `last_state_x`, `last_state_v`, `last_state_a` in `assist_extras`. Doing it this way avoids having to allocate, then filling, then freeing `x0`, `v0`, `a0` during whenever an interpolation is needed.

I've also made use of REBOUND's `pretimestep_modification` to store the `last_state_*` variables. The might make it easier to do the interpolation in the "plain interface" (whenever I get around to it). 

The code should give the exact same results as before, just a bit faster and with fewer lines of code.