### PR TITLE
Using the ASSIST interpolation from the plain interface

### DIFF
--- a/examples/plain_interface_substeps/Makefile
+++ b/examples/plain_interface_substeps/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.c  $(ASSIST_DIR)/src/*.h
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/examples/plain_interface_substeps/problem.c
+++ b/examples/plain_interface_substeps/problem.c
@@ -1,0 +1,57 @@
+/**
+ * This example demonstrates how to use ASSIST to integrate two test particles in 
+ * the field of the Sun, planets, moon, and a set of massive asteroids, whose
+ * positions come from JPL's DE440/441 ephemeris.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include "rebound.h"
+#include "assist.h"
+
+int main(int argc, char* argv[]){
+    // Create a REBOUND simulation
+    struct reb_simulation* r = reb_create_simulation();
+    
+    // Attach the ASSIST framework
+    struct assist_extras* ax = assist_attach(r);
+
+    // Initial time, relative to ax->jd_ref
+    r->t = 7304.5;
+
+    // Add a particle to the REBOUND simulation.
+    reb_add_fmt(r, "x y z vx vy vz",
+        3.3388753502614090e+00,   // x in AU
+        -9.1765182678903168e-01,  // y
+        -5.0385906775843303e-01,  // z
+        2.8056633153049852e-03,   // vx in AU/day
+        7.5504086883996860e-03,   // vy
+        2.9800282074358684e-03);  // vz
+
+    // Final integration time (relative to ax->jd_ref)
+    double tend = 7404.5;  
+
+    // Generate outputs with a fixed interval
+    double next_output = r->t; 
+    double output_interval = 8; 
+    double* output_state = malloc(r->N*6);
+
+    // Integrate until we reach tend or an error occurs
+    while (r->t < tend && r->status <= 0){
+        reb_step(r);
+
+        while (r->t >= next_output) {
+            printf("t = %.3f\n", next_output);
+            double h = (next_output - (r->t - r->dt_last_done))/ r->dt_last_done;
+            assist_interpolate(r, h, output_state);
+            for(int i=0; i<r->N; i++){
+                printf("\tx = %.12f \ty = %.12f \tz = %.12f\n", output_state[i*6+0], output_state[i*6+1], output_state[i*6+2]);
+            }
+            next_output += output_interval;
+        }
+    }
+
+    // Clean up memory
+    assist_free(ax);
+    reb_free_simulation(r);
+}
+

--- a/examples/plain_interface_substeps/problem.c
+++ b/examples/plain_interface_substeps/problem.c
@@ -32,6 +32,7 @@ int main(int argc, char* argv[]){
     // Final integration time (relative to ax->jd_ref)
     double tend = 7404.5;  
 
+    ///////////////////////////////////////////
     // Generate outputs with a fixed interval
     double next_output = r->t; 
     double output_interval = 8; 
@@ -39,7 +40,7 @@ int main(int argc, char* argv[]){
 
     // Integrate until we reach tend or an error occurs
     while (r->t < tend && r->status <= 0){
-        reb_integrate(r, next_output); // This might overshoot.
+        reb_integrate(r, next_output); // Do the actual integration. This might overshoot.
 
         while (r->t >= next_output) { // do interpolation to get outputs
             printf("t = %.3f     steps = %d\n", next_output,r->steps_done);
@@ -51,6 +52,35 @@ int main(int argc, char* argv[]){
             next_output += output_interval;
         }
     }
+
+    /////////////////////////////////////////////////////////////
+    // Generate outputs at nodes for Chebyshev interpolation 
+    double interval = 30;
+    tend += 200;
+    const int N = 10;
+    double nodes[N];
+    for (int k=0; k<N; k++){
+        nodes[k] = cos((2.0*k+1.0)*M_PI/(2.0*N))/2.0 + 0.5;
+    } 
+    int counter = 0; // steps through 0 to N-1
+    
+
+    // Integrate until we reach tend or an error occurs
+    while (r->t < tend && r->status <= 0){
+        reb_integrate(r, next_output); // Do the actual integration. This might overshoot.
+
+        while (r->t >= next_output) { // do interpolation to get outputs
+            printf("t = %.3f     steps = %d       counter = %d\n", next_output, r->steps_done, counter);
+            double h = (next_output - (r->t - r->dt_last_done))/ r->dt_last_done;
+            assist_interpolate(r, h, output_state);
+            for(int i=0; i<r->N; i++){
+                printf("\tx = %.12f \ty = %.12f \tz = %.12f\n", output_state[i*6+0], output_state[i*6+1], output_state[i*6+2]);
+            }
+            next_output += interval*nodes[counter];
+            counter = (counter+1)%N;
+        }
+    }
+
 
     // Clean up memory
     assist_free(ax);

--- a/examples/plain_interface_substeps/problem.c
+++ b/examples/plain_interface_substeps/problem.c
@@ -18,6 +18,8 @@ int main(int argc, char* argv[]){
     // Initial time, relative to ax->jd_ref
     r->t = 7304.5;
 
+    r->exact_finish_time = 0; // Let IAS overshoot. Use interpolation to get outputs.
+
     // Add a particle to the REBOUND simulation.
     reb_add_fmt(r, "x y z vx vy vz",
         3.3388753502614090e+00,   // x in AU
@@ -37,10 +39,10 @@ int main(int argc, char* argv[]){
 
     // Integrate until we reach tend or an error occurs
     while (r->t < tend && r->status <= 0){
-        reb_step(r);
+        reb_integrate(r, next_output); // This might overshoot.
 
-        while (r->t >= next_output) {
-            printf("t = %.3f\n", next_output);
+        while (r->t >= next_output) { // do interpolation to get outputs
+            printf("t = %.3f     steps = %d\n", next_output,r->steps_done);
             double h = (next_output - (r->t - r->dt_last_done))/ r->dt_last_done;
             assist_interpolate(r, h, output_state);
             for(int i=0; i<r->N; i++){

--- a/examples/simplest/problem.c
+++ b/examples/simplest/problem.c
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]){
 
     printf("entering integration_function\n");
     int n_steps;
-    int status = integration_function(jd_ref,
+    int status = assist_integrate(jd_ref,
 				      tstart, tend, tstep, 0, 1e-9,
 				      n_particles, instate,
 				      part_paramst,

--- a/src/assist.c
+++ b/src/assist.c
@@ -457,13 +457,13 @@ static void assist_heartbeat(struct reb_simulation* sim){
 
     }else if(sim->steps_done > steps_done){
 
-        int time_offset = (step-1)*nsubsteps+1;
         double* hg = assist->hg;
 
         // Loop over substeps
         for(int n=1;n<(nsubsteps+1);n++) {	    
-            output_t[time_offset] = sim->t + sim->dt_last_done * (-1.0 + hg[n]);
-            assist_interpolate(sim, hg[n], output_state +  ((step-1)*nsubsteps + n)*6*N ); 
+            int offset = (step-1)*nsubsteps;
+            output_t[offset+n] = sim->t + sim->dt_last_done * (-1.0 + hg[n]);
+            assist_interpolate(sim, hg[n], output_state +  (offset + n)*6*N );
         }
     }
     steps_done = sim->steps_done;

--- a/src/assist.c
+++ b/src/assist.c
@@ -344,7 +344,19 @@ void assist_interpolate(struct reb_simulation* sim, double h, double* output){
     // Convenience variable.  The 'br' field contains the
     // set of coefficients from the last completed step.
     const struct reb_dpconst7 b  = dpcast(sim->ri_ias15.br);
-    if (b.p0 == NULL) return; // arrays not allocated
+    if (b.p0 == NULL){
+       // arrays not allocated yet, just return current state
+        for(int j=0;j<N;j++) {
+            int offset = 6*j;
+            output[offset+0] = sim->particles[j].x;
+            output[offset+1] = sim->particles[j].y;
+            output[offset+2] = sim->particles[j].z;
+            output[offset+3] = sim->particles[j].vx;
+            output[offset+4] = sim->particles[j].vy;
+            output[offset+5] = sim->particles[j].vz;
+        }
+        return;
+    }
 
     double* x0 = assist->last_state_x;
     double* v0 = assist->last_state_v;

--- a/src/assist.h
+++ b/src/assist.h
@@ -73,7 +73,10 @@ enum ASSIST_FORCES {
 struct assist_extras {
     struct reb_simulation* sim;
     int geocentric;
-    tstate* last_state;
+    double last_state_t;
+    double* last_state_x;
+    double* last_state_v;
+    double* last_state_a;
     int nsubsteps;
     double* hg;
     //particle_params* particle_params;

--- a/src/assist.h
+++ b/src/assist.h
@@ -118,6 +118,8 @@ struct reb_particle assist_get_particle(struct assist_extras* assist, const int 
 void assist_initialize(struct reb_simulation* sim, struct assist_extras* assist); // Initializes all pointers and values.
 void assist_free_pointers(struct assist_extras* assist);
 
+void assist_interpolate(struct reb_simulation* sim, double h, double* output);
+
 int assist_integrate(double jd_ref,
 		     double tstart, double tend, double tstep,
 		     int geocentric,

--- a/src/assist.h
+++ b/src/assist.h
@@ -41,15 +41,6 @@ extern const char* assist_version_str;    ///< Version string.
 extern const char* assist_githash_str;    ///< Current git hash.
 
 typedef struct {
-  double t, x, y, z, vx, vy, vz, ax, ay, az;
-} tstate;
-
-typedef struct {
-    double t;
-    tstate* tstates;
-} ephem_block;
-
-typedef struct {
     double A1;
     double A2;
     double A3;        


### PR DESCRIPTION
I'm playing around with how to best use the ASSIST interpolation without relying on the `assist_integrate` function. The reason for this is that I think people will probably have rather specific requirements as to when they require an output. So the goal is to make this as flexible as possible. 

Have a look at this example which currently generates outputs at equidistant spaces first, then switches to a some Chebyshev nodes (just as an example). 
https://github.com/hannorein/assist/blob/plain_interpolation/examples/plain_interface_substeps/problem.c

I'm still not very happy with it. It seems too complicated. 