### PR TITLE
assist_ephem framework

### DIFF
--- a/examples/asteroid/problem.c
+++ b/examples/asteroid/problem.c
@@ -38,12 +38,12 @@ int main(int argc, char* argv[]){
     double* outstate = (double *) malloc((n_alloc)*6*sizeof(double));
     double* outtime  = (double *) malloc((n_alloc+1)*sizeof(double));
 
-    assist_ephem_init("/Users/mholman/assist/data/linux_m13000p17000.441",
-		      "/Users/mholman/assist/data/sb441-n16.bsp");
+    struct assist_ephem* ephem = assist_ephem_init("../../data/linux_m13000p17000.441",
+		      "../../data/sb441-n16.bsp");
 
     int n_steps_done;
     int status = assist_integrate(
-            jd_ref,                 // I do not understand what this variable does
+            ephem,                  // assist_ephem. NULL will try to construct it using defaults.
             tstart, tend, tstep,    // Time range of integration 
             0,                      // 1=geocentric, 0=barycentric
             1e-9,                   // epsilon

--- a/examples/plain_interface/problem.c
+++ b/examples/plain_interface/problem.c
@@ -11,16 +11,23 @@
 int main(int argc, char* argv[]){
     // Create a REBOUND simulation
     struct reb_simulation* r = reb_create_simulation();
+
+
+    // Load the ephemeris data
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_m13000p17000.441",
+            "../../data/sb441-n16.bsp");
+    
+    // One has the option to change other setting.
+    ephem->jd_ref = 2451545.0; // Reference JD. This line can be commented out as this is the default.
     
     // Attach the ASSIST framework
     // This will set the additional force routine in the REBOUND simulation,
     // the IAS15 integrator, the gravity module, etc.
-    struct assist_extras* ax = assist_attach(r);
+    struct assist_extras* ax = assist_attach(r, ephem);
 
-    // One has the option to change other setting.
-    ax->jd_ref = 2451545.0; // Reference JD. This line can be commented out as this is the default.
     
-    // Initial time, relative to ax->jd_ref
+    // Initial time, relative to ephem->jd_ref
     r->t = 7304.5;
 
     // Set any other integrator settings, for example a minimum timestep
@@ -39,7 +46,7 @@ int main(int argc, char* argv[]){
 
 
     // Query the position of the sun at current simulation time.
-    struct reb_particle sun = assist_get_particle(ax, 0, r->t); // 0 stans dfor sun
+    struct reb_particle sun = assist_get_particle(ephem, 0, r->t); // 0 stans dfor sun
     
     // Add another test particle using orbital parameters relative to the sun
     reb_add_fmt(r, "a e omega primary",
@@ -50,7 +57,7 @@ int main(int argc, char* argv[]){
     
     
     // Query the position of the earth at current simulation time.
-    struct reb_particle earth = assist_get_particle(ax, 3, r->t); // 3 stands for earth
+    struct reb_particle earth = assist_get_particle(ephem, 3, r->t); // 3 stands for earth
     printf("%f %f %f \n", earth.x, earth.y, earth.z);
     
     // Add another test particle in orbit around the Earth
@@ -59,7 +66,7 @@ int main(int argc, char* argv[]){
         earth);
 
 
-    // Final integration time (relative to ax->jd_ref)
+    // Final integration time (relative to ephem->jd_ref)
     double tend = 7404.5;  
 
     // Integrate until we reach tend or an error occurs
@@ -68,7 +75,7 @@ int main(int argc, char* argv[]){
        reb_integrate(r, r->t + 20.0);
 
        // Output test particle positions
-       printf("t = %.1f\n", r->t + ax->jd_ref);
+       printf("t = %.1f\n", r->t + ephem->jd_ref);
        for(int i=0; i<r->N; i++){
            struct reb_particle p = r->particles[i];
            printf("particles[%d]:  \tx = %.12f \ty = %.12f \tz = %.12f\n", i, p.x, p.y, p.z);

--- a/examples/simplest/problem.c
+++ b/examples/simplest/problem.c
@@ -40,6 +40,11 @@ void read_inputs(char *filename, double* tepoch, double* tstart, double* tend, d
 */
 
 int main(int argc, char* argv[]){
+    // Load the ephemeris data
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_m13000p17000.441",
+            "../../data/sb441-n16.bsp");
+    ephem->jd_ref = 2451545.0;
 
     // These variables are used to capture the results of read_inputs()
     double tepoch, tstart, tend, tstep;
@@ -51,7 +56,6 @@ int main(int argc, char* argv[]){
     int *invar_part; // This stores the particle index that goes with the variational particle
     double *invar;
     double* cov_mat;
-    double jd_ref = 2451545.0;
     
     //particle_params* part_paramst = NULL;
     //particle_params* invar_part_params = NULL;
@@ -99,7 +103,7 @@ int main(int argc, char* argv[]){
 
     printf("entering integration_function\n");
     int n_steps;
-    int status = assist_integrate(jd_ref,
+    int status = assist_integrate(ephem,
 				      tstart, tend, tstep, 0, 1e-9,
 				      n_particles, instate,
 				      part_paramst,

--- a/src/forces.h
+++ b/src/forces.h
@@ -29,7 +29,7 @@
 // It includes all forces, including gravity.
 void assist_additional_forces(struct reb_simulation* sim);
 
-int assist_all_ephem(const int i, const double jd_ref, const double t, double* const GM,
+int assist_all_ephem(struct assist_ephem* ephem, const int i, const double t, double* const GM,
 		      double* const x, double* const y, double* const z,
 		      double* const vx, double* const vy, double* const vz,
 		      double* const ax, double* const ay, double* const az

--- a/unit_tests/benchmark/problem.c
+++ b/unit_tests/benchmark/problem.c
@@ -9,11 +9,12 @@
 #include "assist.h"
 
 double runtime(){
-
-    assist_ephem_init(NULL, NULL);
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_m13000p17000.441",
+            "../../data/sb441-n16.bsp");
     
     struct reb_simulation* r = reb_create_simulation();
-    struct assist_extras* ax = assist_attach(r);
+    struct assist_extras* ax = assist_attach(r, ephem);
     r->t = 8416.5;
 
     // Asteroid Holman with slightly different initial conditions
@@ -33,6 +34,7 @@ double runtime(){
     gettimeofday(&time_end,NULL);
     
     assist_free(ax);
+    assist_ephem_free(ephem);
     reb_free_simulation(r);
 
     return time_end.tv_sec-time_beginning.tv_sec+(time_end.tv_usec-time_beginning.tv_usec)/1e6;
@@ -62,5 +64,6 @@ int main(int argc, char* argv[]){
     printf("%.6fs %.6fs %s %s %s\n", mean, std, assist_version_str, assist_build_str, assist_githash_str);
     fprintf(of, "%.6fs %.6fs %s %s %s\n", mean, std, assist_version_str, assist_build_str, assist_githash_str);
     fclose(of);
+    
 }
 

--- a/unit_tests/holman/problem.c
+++ b/unit_tests/holman/problem.c
@@ -9,6 +9,11 @@
 #include "assist.h"
 
 int main(int argc, char* argv[]){
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_m13000p17000.441",
+            "../../data/sb441-n16.bsp");
+    ephem->jd_ref = 2451545.0;
+    
     // Initial conditions of asteroid Holman
     int n_particles = 1;    
     double* state = malloc(n_particles*6*sizeof(double));
@@ -20,7 +25,6 @@ int main(int argc, char* argv[]){
     state[4] = -1.027075301472321E-02 ;  // vy
     state[5] = -4.195690627695180E-03;  // vz
    
-    double jd_ref = 2451545.0;  // All times are emasured relative to this Julian date 
     double tstart = 8416.5;     // Initial time 
     double tend = 8446.5 ;       // Final time
     double tstep = 20;          // Integration step size. 
@@ -38,15 +42,9 @@ int main(int argc, char* argv[]){
     double* outstate = (double *) malloc((n_alloc)*6*sizeof(double));
     double* outtime  = (double *) malloc((n_alloc)*sizeof(double));
 
-    int ephem_res = assist_ephem_init(NULL, NULL);
-
-    if(ephem_res != 0){
-	exit(-1);
-    }
-
     int n_steps_done;
     int status = assist_integrate(
-            jd_ref,                 // I do not understand what this variable does
+            ephem, 
             tstart, tend, tstep,    // Time range of integration 
             0,                      // 1=geocentric, 0=barycentric
             1e-9,                   // epsilon

--- a/unit_tests/plain_interface/problem.c
+++ b/unit_tests/plain_interface/problem.c
@@ -10,11 +10,12 @@
 
 int main(int argc, char* argv[]){
 
-    assist_ephem_init(NULL, NULL);
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_m13000p17000.441",
+            "../../data/sb441-n16.bsp");
     
     struct reb_simulation* r = reb_create_simulation();
-    struct assist_extras* ax = assist_attach(r);
-    ax->jd_ref = 2451545.0; // Reference JD. This line can be commented out as this is the default.
+    struct assist_extras* ax = assist_attach(r, ephem);
     r->t = 8416.5;
 
     // Initial conditions of asteroid Holman
@@ -45,5 +46,7 @@ int main(int argc, char* argv[]){
     double diff_vz = fabs(r->particles[0].vz-r->particles[1].vz)*au2meter;
     assert(diff_vz < 5e-3); // require that integration error is less than 5mm/day after 30 day integration
         
+    assist_free(ax);
+    assist_ephem_free(ephem);
 }
 

--- a/unit_tests/plain_interface_reverse/problem.c
+++ b/unit_tests/plain_interface_reverse/problem.c
@@ -9,11 +9,13 @@
 #include "assist.h"
 
 int main(int argc, char* argv[]){
-
-    assist_ephem_init(NULL, NULL);
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_m13000p17000.441",
+            "../../data/sb441-n16.bsp");
+    ephem->jd_ref = 2451545.0;
     
     struct reb_simulation* r = reb_create_simulation();
-    struct assist_extras* ax = assist_attach(r);
+    struct assist_extras* ax = assist_attach(r, ephem);
     ax->jd_ref = 2451545.0; // Reference JD. This line can be commented out as this is the default.
     r->t = 8446.5;
 
@@ -45,5 +47,7 @@ int main(int argc, char* argv[]){
     double diff_vz = fabs(r->particles[0].vz-r->particles[1].vz)*au2meter;
     assert(diff_vz < 5e-3); // require that integration error is less than 5mm/day after 30 day integration
         
+    assist_free(ax);
+    assist_ephem_free(ephem);
 }
 


### PR DESCRIPTION
This implements the new `assist_ephem` struct and framework as we discussed in #7. There is probably some cleanup that can be done.

I've moved the `jd_ref` variable to `assist_ephem` because it is used when accessing the ephemeris data and therefore needed even if one is not using assist to integrate orbits.

I'm using the `assist_ephem_init()` function that you've implemented so the logic to find the default files is the same. 

A lot of function arguments had to be changed. But otherwise there was really not much to do!