### PR TITLE
compiles with gcc version 6.3.0

### DIFF
--- a/src/forces.c
+++ b/src/forces.c
@@ -200,9 +200,9 @@ static int planet_ephem(struct assist_ephem* ephem, const int i, const double jd
 
     // Calculate GM values for Earth and Moon
     // from Earth-moon ratio and sum.
-    const static double em_r = JPL_EPHEM_EMRAT;
-    const static double GMe = em_r/(1.+em_r) * JPL_EPHEM_GMB;
-    const static double GMm = 1./(1.+em_r) * JPL_EPHEM_GMB;
+#define    em_r JPL_EPHEM_EMRAT
+#define    GMe (em_r/(1.+em_r) * JPL_EPHEM_GMB)
+#define    GMm (1./(1.+em_r) * JPL_EPHEM_GMB)
 
     // The values below are G*mass.
     // Units are solar masses, au, days.


### PR DESCRIPTION
Some older compilers cannot handle the initialization of a constant array the way it was done. This change should fix that. It shouldn't change anything. The constants are still calculated at compile time, just using precompiler directives.