### PR TITLE
Roundtrip unit test

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -56,6 +56,11 @@ jobs:
         run: |
           make
           LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Test roundtrip
+        working-directory: ./unit_tests/roundtrip/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
       - name: Run benchmark
         working-directory: ./unit_tests/benchmark
         run: |

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -51,6 +51,11 @@ jobs:
         run: |
           make
           LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Test ephem_cache 
+        working-directory: ./unit_tests/ephem_cache/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
       - name: Run benchmark
         working-directory: ./unit_tests/benchmark
         run: |

--- a/src/assist.c
+++ b/src/assist.c
@@ -199,12 +199,24 @@ void assist_initialize(struct reb_simulation* sim, struct assist_extras* assist,
 
 void assist_free_pointers(struct assist_extras* assist){
     assist_detach(assist->sim, assist);
-    free(assist->last_state_x);
-    free(assist->last_state_v);
-    free(assist->last_state_a);
-    free(assist->ephem_cache->items);
-    free(assist->ephem_cache->t);
-    free(assist->ephem_cache);
+    if (assist->last_state_x){
+        free(assist->last_state_x);
+    }
+    if (assist->last_state_v){
+        free(assist->last_state_v);
+    }
+    if(assist->last_state_a){
+        free(assist->last_state_a);
+    }
+    if (assist->ephem_cache){
+        if (assist->ephem_cache->items){
+            free(assist->ephem_cache->items);
+        }
+        if (assist->ephem_cache->t){
+            free(assist->ephem_cache->t);
+        }
+        free(assist->ephem_cache);
+    }
     if (assist->extras_should_free_ephem){
         assist_ephem_free(assist->ephem);
     }

--- a/unit_tests/ephem_cache/Makefile
+++ b/unit_tests/ephem_cache/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/ephem_cache/problem.c
+++ b/unit_tests/ephem_cache/problem.c
@@ -1,0 +1,60 @@
+/**
+ * Tests the ephem_cache
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "rebound.h"
+#include "assist.h"
+
+struct reb_particle integrate(struct assist_ephem* ephem, int cache_on){
+    struct reb_simulation* r = reb_create_simulation();
+    struct assist_extras* ax = assist_attach(r, ephem);
+    if (cache_on == 0){
+        ax->ephem_cache = NULL;
+    }
+
+    double t0 = 2458849.5-ephem->jd_ref;
+    r->t = t0; 
+
+    // Initial conditions of asteroid Holman
+    reb_add_fmt(r, "x y z vx vy vz",
+        3.3388753502614090e+00, -9.1765182678903168e-01, -5.0385906775843303e-01,
+        2.8056633153049852e-03,  7.5504086883996860e-03,  2.9800282074358684e-03);
+   
+    reb_integrate(r,  t0 + 1000);
+    assert(r->t == t0+1000);
+
+    struct reb_particle p = r->particles[0];
+    assist_free(ax);
+    reb_free_simulation(r);
+    return p;
+}
+
+int main(int argc, char* argv[]){
+
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_p1550p2650.440",
+            "../../data/sb441-n16.bsp");
+    if (ephem == NULL){
+        fprintf(stderr,"Error initializing assist_ephem.\n");
+        exit(1);
+    }
+   
+    {
+        struct reb_particle p0 = integrate(ephem, 0); // Run without cache
+        struct reb_particle p1 = integrate(ephem, 1); // Run with cache
+        // Check that ephem_cache does not affect result
+        assert(p0.x == p1.x);
+        assert(p0.y == p1.y);
+        assert(p0.z == p1.z);
+        assert(p0.vx == p1.vx);
+        assert(p0.vy == p1.vy);
+        assert(p0.vz == p1.vz);
+        printf("Check passed.\n");
+    }
+        
+     
+    assist_ephem_free(ephem);
+}
+

--- a/unit_tests/roundtrip/Makefile
+++ b/unit_tests/roundtrip/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/roundtrip/problem.c
+++ b/unit_tests/roundtrip/problem.c
@@ -1,0 +1,80 @@
+/**
+ * A unit test integrating the asteroid Holman for 30 days, then comparing the 
+ * position and coordinates to JPL Horizon data.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "rebound.h"
+#include "assist.h"
+
+double roundtrip(struct assist_ephem* ephem, double trange){
+    struct reb_simulation* r = reb_create_simulation();
+    struct assist_extras* ax = assist_attach(r, ephem);
+
+    double t0 = 2458849.5-ephem->jd_ref;
+    double x0 = 3.3388753502614090e+00;
+    double y0 = -9.1765182678903168e-01;
+    double z0 = -5.0385906775843303e-01;
+
+    r->t = t0; 
+
+    // Initial conditions of asteroid Holman
+    reb_add_fmt(r, "x y z vx vy vz",
+        x0, y0, z0,
+        2.8056633153049852e-03,  7.5504086883996860e-03,  2.9800282074358684e-03);
+   
+    reb_integrate(r,  t0 + trange);
+    assert(r->t == t0+trange);
+    r->dt = 0.01; 
+    reb_integrate(r,  t0);
+    assert(r->t == t0);
+
+    double dx = r->particles[0].x - x0;
+    double dy = r->particles[0].y - y0;
+    double dz = r->particles[0].z - z0;
+
+    double au2meter = 149597870700;
+    double d = sqrt(dx*dx + dy*dy + dz*dz)*au2meter;
+   
+    assist_free(ax);
+    reb_free_simulation(r);
+    return d;
+}
+
+int main(int argc, char* argv[]){
+
+    struct assist_ephem* ephem = assist_ephem_init(
+            "../../data/linux_p1550p2650.440",
+            "../../data/sb441-n16.bsp");
+    if (ephem == NULL){
+        fprintf(stderr,"Error initializing assist_ephem.\n");
+        exit(1);
+    }
+   
+  //  {
+  //      double r0 = roundtrip(ephem, 100);
+  //      printf("distance: %fm\n",r0);
+  //      assert(r0 < 0.002); // required accuracy in m
+  //  }
+  //  {
+  //      double r0 = roundtrip(ephem, 1000);
+  //      printf("distance: %fm\n",r0);
+  //      assert(r0 < 0.01); // required accuracy in m
+  //  }
+  //  {
+  //      double r0 = roundtrip(ephem, 10000);
+  //      printf("distance: %fm\n",r0);
+  //      assert(r0 < 0.05); // required accuracy in m
+  //  }
+    for (double trange = 10000; trange<1e5; trange*=1.05)
+    {
+        double r0 = roundtrip(ephem, trange);
+        printf("trange = %f   error: %fm\n",trange, r0);
+        //assert(r0 < 0.2); // required accuracy in m
+    }
+        
+     
+    assist_ephem_free(ephem);
+}
+

--- a/unit_tests/roundtrip/problem.c
+++ b/unit_tests/roundtrip/problem.c
@@ -24,10 +24,19 @@ double roundtrip(struct assist_ephem* ephem, double trange){
         x0, y0, z0,
         2.8056633153049852e-03,  7.5504086883996860e-03,  2.9800282074358684e-03);
    
-    reb_integrate(r,  t0 + trange);
-    assert(r->t == t0+trange);
-    r->dt = 0.01; 
+    //reb_integrate(r,  t0 + trange);
+    //assert(r->t == t0+trange);
+    while (r->t < t0 + trange){
+        reb_step(r);
+    }
+    r->dt *= -1; 
+//    while (r->t > t0){
+//        reb_step(r);
+//    }
+    printf("tt= %f\n", r->t-t0);
     reb_integrate(r,  t0);
+    printf("dt= %f\n", r->dt_last_done);
+    printf("dt= %f\n", r->dt);
     assert(r->t == t0);
 
     double dx = r->particles[0].x - x0;


### PR DESCRIPTION
While coding up the roundtrip test from the paper as a unit test, I've noticed something that doesn't seem quite right. The error seems to depend on the range in a very non-smooth way (have a look at the output below). The plot in the notebook and paper doesn't have that many data points, so I'm not sure if this is a new problem. In any case, I don't think this is correct as of right now. I suspect this is related to how the `reb_integrate` function handles the last timestep, which depending on where the timesteps fall, might have to be much smaller than a "normal" timestep. (but it could also be something completely different)

```
trange = 41161.355954   error: 0.139017m
trange = 43219.423752   error: 2897.963781m
trange = 45380.394939   error: 0.061683m
trange = 47649.414686   error: 0.146603m
trange = 50031.885420   error: 0.314383m
trange = 52533.479691   error: 0.077800m
trange = 55160.153676   error: 0.495380m
trange = 57918.161360   error: 0.321240m
trange = 60814.069428   error: 4068.455833m
trange = 63854.772899   error: 0.308811m
trange = 67047.511544   error: 7.797359m
trange = 70399.887121   error: 0.589816m
```