### PR TITLE
example renamed to 'asteroid'

### DIFF
--- a/docs/source/c_quickstart.rst
+++ b/docs/source/c_quickstart.rst
@@ -41,7 +41,7 @@ go to one of the example directories and compile the problem file in the directo
 
 .. code-block:: console
 
-	cd assist/examples/plain_interface
+	cd assist/examples/asteroid
 	make
 
 And run the example with:


### PR DESCRIPTION
plain_interface changed to asteroid in C quickstart doc.