### PR TITLE
Implemented better error handling for assist.Ephem()

### DIFF
--- a/assist/__init__.py
+++ b/assist/__init__.py
@@ -22,6 +22,14 @@ __build__ = c_char_p.in_dll(clibassist, "assist_build_str").value.decode('ascii'
 # Githash
 __githash__ = c_char_p.in_dll(clibassist, "assist_githash_str").value.decode('ascii')
 
+def assist_error_messages(e):
+    e_N = c_int.in_dll(clibassist, "assist_error_messages_N").value
+    if e >= e_N:
+        raise RuntimeError("And error occured while trying to process an ASSIST error message.")
+    ccpp  = c_char_p * e_N
+    message = ccpp.in_dll(clibassist, "assist_error_messages")[e]
+    return message.decode("ascii")
+
 try:
     import pkg_resources
     moduleversion = pkg_resources.require("assist")[0].version

--- a/assist/ephem.py
+++ b/assist/ephem.py
@@ -48,12 +48,7 @@ class Ephem(Structure):
         clibassist.assist_ephem_init.restype = c_int
         ret = clibassist.assist_ephem_init(byref(self), c_char_p(planets_path), c_char_p(asteroids_path))
         if ret != 0:
-            if ret == 1:
-                raise RuntimeError("JPL planet ephemeris file not found.")
-            if ret == 2:
-                raise RuntimeError("JPL asteroid ephemeris file not found.")
-
-            raise RuntimeError("An error occured while creating the ephemeris structure.")
+            raise RuntimeError(assist_error_messages(ret))
 
     def get_particle(self, body, t):
         if isinstance(body, str):

--- a/assist/ephem.py
+++ b/assist/ephem.py
@@ -1,4 +1,4 @@
-from . import clibassist
+from . import clibassist, assist_error_messages
 from ctypes import Structure, c_double, POINTER, c_int, c_uint, c_long, c_ulong, c_void_p, c_char_p, CFUNCTYPE, byref, c_uint32, c_uint, cast, c_char
 import rebound
 import assist
@@ -67,8 +67,11 @@ class Ephem(Structure):
         if not isinstance(body, int):
             raise ValueError("Expecting integer for body id.")
 
-        clibassist.assist_get_particle.restype = rebound.Particle
-        p = clibassist.assist_get_particle(byref(self), c_int(body), c_double(t))
+        clibassist.assist_get_particle_with_error.restype = rebound.Particle
+        e = c_int(0)
+        p = clibassist.assist_get_particle_with_error(byref(self), c_int(body), c_double(t), byref(e))
+        if e.value:
+            raise RuntimeError(assist_error_messages(e.value))
         return p
 
 

--- a/src/assist.c
+++ b/src/assist.c
@@ -110,7 +110,6 @@ int assist_ephem_init(struct assist_ephem* ephem, char *user_planets_path, char 
      */
 
     if(user_planets_path == NULL && getenv("ASSIST_DIR")==NULL){
-        fprintf(stderr, "No user or default planet ephemeris file\n");
         return ASSIST_ERROR_EPHEM_FILE;	  
     }
 
@@ -121,12 +120,10 @@ int assist_ephem_init(struct assist_ephem* ephem, char *user_planets_path, char 
     }
 
     if ((ephem->jpl = assist_jpl_init(planets_path)) == NULL) {
-        printf("Couldn't find planet ephemeris file: %s\n", planets_path);	  
         return ASSIST_ERROR_EPHEM_FILE;	  
     }
 
     if(user_asteroids_path == NULL && getenv("ASSIST_DIR")==NULL){
-        fprintf(stderr, "No user or asteroid ephemeris file\n");
         return ASSIST_ERROR_AST_FILE;	  
     }
 
@@ -137,7 +134,6 @@ int assist_ephem_init(struct assist_ephem* ephem, char *user_planets_path, char 
     }
 
     if ((ephem->spl = assist_spk_init(asteroids_path)) == NULL) {
-        printf("Couldn't find asteroid ephemeris file: %s\n", asteroids_path);
         return ASSIST_ERROR_AST_FILE;	  
     }
 
@@ -146,8 +142,10 @@ int assist_ephem_init(struct assist_ephem* ephem, char *user_planets_path, char 
 
 struct assist_ephem* assist_ephem_create(char *user_planets_path, char *user_asteroids_path){
     struct assist_ephem* ephem = calloc(1, sizeof(struct assist_ephem));
-    int ret = assist_ephem_init(ephem, user_planets_path, user_asteroids_path);
-    if (ret != ASSIST_SUCCESS){
+    int error = assist_ephem_init(ephem, user_planets_path, user_asteroids_path);
+    if (error != ASSIST_SUCCESS){
+        fprintf(stderr, "(ASSIST) An error occured while trying to initialize the ephemeris structure.\n");
+        fprintf(stderr, "(ASSIST) %s\n", assist_error_messages[error]);
         assist_ephem_free(ephem);
         return NULL;
     }
@@ -169,7 +167,7 @@ void assist_ephem_free(struct assist_ephem* ephem){
 
 struct assist_extras* assist_attach(struct reb_simulation* sim, struct assist_ephem* ephem){  
     if (sim == NULL){
-        fprintf(stderr, "ASSIST Error: Simulation pointer passed to assist_attach was NULL.\n");
+        fprintf(stderr, "(ASSIST) Error: Simulation pointer passed to assist_attach was NULL.\n");
         return NULL;
     }
     int extras_should_free_ephem = 0;
@@ -177,7 +175,7 @@ struct assist_extras* assist_attach(struct reb_simulation* sim, struct assist_ep
         // Try default 
         ephem = assist_ephem_create(NULL, NULL);
         if (ephem == NULL){
-            fprintf(stderr, "ASSIST Error: Ephemeris pointer passed to assist_attach was NULL. Initialization with default path failed.\n");
+            fprintf(stderr, "(ASSIST) Error: Ephemeris pointer passed to assist_attach was NULL. Initialization with default path failed.\n");
             return NULL;
         }
         extras_should_free_ephem = 1;
@@ -274,7 +272,7 @@ void assist_detach(struct reb_simulation* sim, struct assist_extras* assist){
 
 void assist_error(struct assist_extras* assist, const char* const msg){
     if (assist->sim == NULL){
-        fprintf(stderr, "ASSIST Error: A Simulation is no longer attached to the ASSIST extras instance. Most likely the Simulation has been freed.\n");
+        fprintf(stderr, "(ASSIST) Error: A Simulation is no longer attached to the ASSIST extras instance. Most likely the Simulation has been freed.\n");
     } else{
         reb_error(assist->sim, msg);
     }

--- a/src/assist.h
+++ b/src/assist.h
@@ -61,13 +61,18 @@ enum ASSIST_FORCES {
     ASSIST_FORCE_GR_POTENTIAL       = 0x100,
 };
 
+// Error code. Corresponding messages are in assist.c
 enum ASSIST_STATUS{
-    ASSIST_SUCCESS,         // no error
-    ASSIST_ERROR_EPHEM_FILE,   // JPL ephemeris file not found
-    ASSIST_ERROR_AST_FILE,     // JPL asteroid file not found
-    ASSIST_ERROR_NAST,         // asteroid number out of range
-    ASSIST_ERROR_NEPHEM,      // planet number out of range
+    ASSIST_SUCCESS,
+    ASSIST_ERROR_EPHEM_FILE,
+    ASSIST_ERROR_AST_FILE,
+    ASSIST_ERROR_NAST,
+    ASSIST_ERROR_NEPHEM,
+    ASSIST_ERROR_COVERAGE,
+    ASSIST_ERROR_N,
 };
+
+extern const char* assist_error_messages[];
 
 enum ASSIST_BODY {
     ASSIST_BODY_SUN         = 0,

--- a/src/forces.c
+++ b/src/forces.c
@@ -78,9 +78,7 @@ void assist_additional_forces(struct reb_simulation* sim){
 	// The offset position is used to adjust the particle positions.
 	int flag = assist_all_ephem(ephem, assist->ephem_cache, ASSIST_BODY_EARTH, t, &GM, &xo, &yo, &zo, &vxo, &vyo, &vzo, &axo, &ayo, &azo);
 	if(flag != ASSIST_SUCCESS){
-	    char outstring[50];
-	    sprintf(outstring, "%s %d %d\n", "Ephemeris error a ", 3, flag);
-	    reb_error(sim, outstring);
+        reb_error(sim, assist_error_messages[flag]);
 	}
     }else{
 	// barycentric
@@ -315,9 +313,7 @@ static void assist_additional_force_direct(struct reb_simulation* sim, double xo
         int flag = assist_all_ephem(ephem, assist->ephem_cache, i, t, &GM, &x, &y, &z, &vx, &vy, &vz, &ax, &ay, &az);
 
         if(flag != ASSIST_SUCCESS){
-            char outstring[50];
-            sprintf(outstring, "%s %d %d\n", "Ephemeris error b ", i, flag);	    
-            reb_error(sim, outstring);
+            reb_error(sim, assist_error_messages[flag]);
         }
 
         // Loop over test particles
@@ -356,9 +352,7 @@ static void assist_additional_force_direct(struct reb_simulation* sim, double xo
 	int flag = assist_all_ephem(ephem, assist->ephem_cache, i, t, &GM, &x, &y, &z, &vx, &vy, &vz, &ax, &ay, &az);
 
 	if(flag != ASSIST_SUCCESS){
-	    char outstring[50];
-	    sprintf(outstring, "%s %d %d\n", "Ephemeris error c ", i, flag);	    	    
-	    reb_error(sim, outstring);
+        reb_error(sim, assist_error_messages[flag]);
 	}
 
     // Skip remainder of calculation if variational particles are not used

--- a/src/planets.c
+++ b/src/planets.c
@@ -274,7 +274,7 @@ enum ASSIST_STATUS assist_jpl_calc(struct jpl_s *jpl, double jd_ref, double jd_r
 
         // check if covered by this file
         if (jd_ref + jd_rel < jpl->beg || jd_ref + jd_rel > jpl->end)
-            return ASSIST_ERROR_EPHEM_FILE;
+            return ASSIST_ERROR_COVERAGE;
 
         // compute record number and 'offset' into record
         blk = (u_int32_t)((jd_ref + jd_rel - jpl->beg) / jpl->inc);

--- a/src/spk.c
+++ b/src/spk.c
@@ -171,6 +171,7 @@ next:	n = (int)val[0] - 1;
 		c = pl->ind[m]++;
 		pl->one[m][c] = sum->one;
 		pl->two[m][c] = sum->two;
+		pl->end[m] = _jul(sum->end);
 	}
 
 	if (n >= 0) {
@@ -261,7 +262,7 @@ enum ASSIST_STATUS assist_spk_calc(struct spk_s *pl, double jde, double rel, int
         return(ASSIST_ERROR_NAST);
     }
         
-    if (jde + rel < pl->beg[m] || jde + rel > pl->beg[m] + pl->ind[m] * pl->res[m]){
+    if (jde + rel < pl->beg[m] || jde + rel > pl->end[m]){
         return ASSIST_ERROR_COVERAGE;
     }
 

--- a/src/spk.c
+++ b/src/spk.c
@@ -260,6 +260,10 @@ enum ASSIST_STATUS assist_spk_calc(struct spk_s *pl, double jde, double rel, int
     if(m<0 || m > pl->num){
         return(ASSIST_ERROR_NAST);
     }
+        
+    if (jde + rel < pl->beg[m] || jde + rel > pl->beg[m] + pl->ind[m] * pl->res[m]){
+        return ASSIST_ERROR_COVERAGE;
+    }
 
     // TODO: again, the units might be handled more
     // generally

--- a/src/spk.h
+++ b/src/spk.h
@@ -58,6 +58,7 @@ struct spk_s {
 	int tar[_SPK_MAX];		// target code
 	int cen[_SPK_MAX];		// centre target
 	double beg[_SPK_MAX];		// begin epoch
+	double end[_SPK_MAX];		// begin epoch
 	double res[_SPK_MAX];		// epoch step
 	int *one[_SPK_MAX];		// record index
 	int *two[_SPK_MAX];		// ... ditto


### PR DESCRIPTION
I've implemented better error handling for the ephemeris queries, especially how errors show up on the python side.

One thing I've added is a check whether the requested time is covered by the asteroid ephemeris file (this was implemented for the planet file, but not for the asteroid one). @cylon359, did I [do this](https://github.com/hannorein/assist/blob/error_messages/src/spk.c#L264) correctly? I'm calculating the end of the coverage like this: 
```c
 pl->beg[m] + pl->ind[m] * pl->res[m]
```

