### PR TITLE
Added pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,4 @@ include src/spk.h
 include README.md
 include LICENSE
 include version.txt
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR adds a very basic `pyproject.toml` file which will be required in future pip versions.