### PR TITLE
Units

### DIFF
--- a/assist/extras.py
+++ b/assist/extras.py
@@ -26,7 +26,7 @@ class Extras(Structure):
         sim._extras_ref = self # add a reference to this instance in sim to make sure it's not garbage collected_ 
         clibassist.assist_init(byref(self), byref(sim), byref(ephem))
         # set up units and frame to allow direct access to JPL Horizons via REBOUND
-        sim.units = ("AU","day","massist")
+        sim.update_units(("au","day","massist"))
         sim.default_plane = "frame"
         self.extras_should_free_ephem = 0
 

--- a/assist/extras.py
+++ b/assist/extras.py
@@ -25,7 +25,9 @@ class Extras(Structure):
     def __init__(self, sim, ephem):
         sim._extras_ref = self # add a reference to this instance in sim to make sure it's not garbage collected_ 
         clibassist.assist_init(byref(self), byref(sim), byref(ephem))
-        sim.units = ("AU","day","sunmass")
+        # set up units and frame to allow direct access to JPL Horizons via REBOUND
+        sim.units = ("AU","day","massist")
+        sim.default_plane = "frame"
         self.extras_should_free_ephem = 0
 
     def __del__(self):

--- a/assist/extras.py
+++ b/assist/extras.py
@@ -25,6 +25,7 @@ class Extras(Structure):
     def __init__(self, sim, ephem):
         sim._extras_ref = self # add a reference to this instance in sim to make sure it's not garbage collected_ 
         clibassist.assist_init(byref(self), byref(sim), byref(ephem))
+        sim.units = ("AU","day","sunmass")
         self.extras_should_free_ephem = 0
 
     def __del__(self):


### PR DESCRIPTION
A very small update. ASSIST will now update the REBOUND frame and the units to match what it is using. With this, one can directly import particles from horizons. For example:

```python
t0 = 2459945.50000
sim = rebound.Simulation()
extras = assist.Extras(sim, ephem)
sim.add("99942", date="JD%.f"%t0)
sim.t = t0 - ephem.jd_ref
```

This requires the latest version of REBOUND to work.

Note this might not be the best time to test it as JPL Horizons seems to have some problems at the moment.