### PR TITLE
Fix difference between C and python in apophis example

### DIFF
--- a/assist/test/test_apophis.py
+++ b/assist/test/test_apophis.py
@@ -1,0 +1,52 @@
+import rebound
+import assist
+import unittest
+import math
+import numpy as np
+
+class TestAssist(unittest.TestCase):
+    def test_apophis(self):
+
+        ephem = assist.Ephem("data/linux_p1550p2650.440", "data/sb441-n16.bsp")
+
+        t_initial = 2.4621385359989386E+06 - ephem.jd_ref # Julian Days relative to jd_ref
+
+        apophis_initial_helio = rebound.Particle(x = -5.5946538550488512E-01, # AU
+                                                 y =  8.5647564757574512E-01,
+                                                 z =  3.0415066217102493E-01,
+                                                 vx= -1.3818324735921638E-02, # AU/day
+                                                 vy= -6.0088275597939191E-03,
+                                                 vz= -2.5805044631309632E-03)
+
+        sun_initial = ephem.get_particle("sun", t_initial)
+
+        apophis_initial = apophis_initial_helio + sun_initial
+
+        sim = rebound.Simulation()
+        sim.add(apophis_initial)
+        sim.t = t_initial
+        sim.ri_ias15.min_dt = 0.001
+        extras = assist.Extras(sim, ephem)
+        extras.gr_eih_sources = 11
+
+        extras.particle_params = np.array([4.999999873689E-13, -2.901085508711E-14, 0.0])
+        t_final = 2.4625030372426095E+06  - ephem.jd_ref
+        sim.integrate(t_final)
+
+        apophis_final_jpl = rebound.Particle(x =  1.7028330901729331E-02,
+                                             y =  1.2193934090901304E+00,
+                                             z =  4.7823589236374386E-01,
+                                             vx= -1.3536187639388663E-02,
+                                             vy=  5.3200999989786943E-04,
+                                             vz= -1.6648346717629861E-05)
+        apophis_final_jpl += ephem.get_particle("sun", t_final) # convert from heliocentric to barycentric
+
+        delta = sim.particles[0] - apophis_final_jpl
+        delta_pos = np.sqrt(delta.x**2 + delta.y**2 + delta.z**2)
+        delta_pos *= 149597870700 # convert from AU to meters
+        self.assertLess(math.fabs(delta_pos), 300) # 300 m accurary
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/jupyter_examples/Apophis.ipynb
+++ b/jupyter_examples/Apophis.ipynb
@@ -93,7 +93,8 @@
     "sim.add(apophis_initial)\n",
     "sim.t = t_initial \n",
     "sim.ri_ias15.min_dt = 0.001\n",
-    "extras = assist.Extras(sim, ephem)"
+    "extras = assist.Extras(sim, ephem)\n",
+    "extras.gr_eih_sources = 11 # Turn on GR for star and all planets"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ libassistmodule = Extension('libassist',
                     runtime_library_dirs = ["."],
                     libraries=['rebound'+suffix[:suffix.rfind('.')]],
                     define_macros=[ ('LIBASSIST', None) ],
-                    extra_compile_args=['-fstrict-aliasing', '-O3','-std=c99', '-fPIC', '-Wpointer-arith', ghash_arg],
+                    extra_compile_args=['-fstrict-aliasing', '-O3','-std=c99', '-fPIC', '-D_GNU_SOURCE', '-Wpointer-arith', ghash_arg],
                     extra_link_args=extra_link_args,
                     )
 

--- a/src/assist.h
+++ b/src/assist.h
@@ -25,10 +25,6 @@
 #ifndef _ASSIST_ASSIST_H_H
 #define _ASSIST_ASSIST_H_H
 
-#ifndef M_PI 
-#define M_PI 3.1415926535879323846
-#endif
-
 #include <stdint.h>
 #include <limits.h>
 #include "rebound.h"

--- a/unit_tests/apophis/problem.c
+++ b/unit_tests/apophis/problem.c
@@ -70,6 +70,7 @@ int main(int argc, char* argv[]){
     double diff = reb_particle_distance(&p_final, &r->particles[0]) * au2meter; // in meter
 
     // Ensure accuracy is better than 250m
+    printf("Difference: %.2f m\n",diff);
     assert(diff < 250); 
 
     assist_free(ax);


### PR DESCRIPTION
This pull request should fix both issues. 
- With the GNU_SOURCE flag, we get the same math constants (I don't understand all the details, but it seems this affects which constants are defined). 
- With the gr_eih_sources flag set to 11 we include GR in the example, making it consistent with the C unit test.