### PR TITLE
Remove unused consts

### DIFF
--- a/src/assist.c
+++ b/src/assist.c
@@ -37,9 +37,6 @@
 #include "planets.h"
 #include "forces.h"
 
-const int reb_max_messages_length = 1024;   // needs to be constant expression for array size
-const int reb_max_messages_N = 10;
-
 #define STRINGIFY(s) str(s)
 #define str(s) #s
 


### PR DESCRIPTION
These clash with names defined in rebound.c, which makes it harder to statically link both rebound and assist into one program. I believe they are unused, though.