### PR TITLE
Added option to change non-gravitational parameters

### DIFF
--- a/assist/extras.py
+++ b/assist/extras.py
@@ -88,6 +88,11 @@ class Extras(Structure):
                  ("steps_done", c_int),
                  ("_forces", c_int),
                  ("gr_eih_sources", c_int),
+	             ("alpha", c_double),
+	             ("nk", c_double),
+	             ("nm", c_double), 
+	             ("nn", c_double),
+	             ("r0", c_double),
         ]
 
 # avoid circular imports

--- a/src/assist.c
+++ b/src/assist.c
@@ -299,6 +299,12 @@ void assist_init(struct assist_extras* assist, struct reb_simulation* sim, struc
                      | ASSIST_FORCE_GR_EIH;
     assist->last_state = NULL; 
     assist->current_state = NULL; 
+    // Default values for non-gravitational parameters
+	assist->alpha = 1.0;
+	assist->nk = 0.0;
+	assist->nm = 2.0;
+	assist->nn = 5.093;
+	assist->r0 = 1.0;
     sim->integrator = REB_INTEGRATOR_IAS15;
     sim->gravity = REB_GRAVITY_NONE;
     sim->extras = assist;

--- a/src/assist.h
+++ b/src/assist.h
@@ -126,6 +126,12 @@ struct assist_extras {
     int steps_done;
     int forces;
     int gr_eih_sources;
+    // Parameters for non-gravitational forces. See forces.c
+	double alpha;
+	double nk;
+	double nm;
+	double nn;
+	double r0;
 };
 
 /**

--- a/src/forces.c
+++ b/src/forces.c
@@ -840,6 +840,19 @@ static void assist_additional_force_non_gravitational(struct reb_simulation* sim
 	//printf(" A123: %le %le %le\n", A1, A2, A3);
 	//fflush(stdout);
 	
+	// 'Oumuamua
+	//double alpha = 0.04083733261;
+	//double nk = 2.6;
+	//double nm = 2.0;
+	//double nn = 3.0;
+	//double r0 = 5.0;
+
+	// Standard --> r^-2
+	double alpha = assist->alpha;
+	double nk = assist->nk;
+	double nm = assist->nm;
+	double nn = assist->nn;
+	double r0 = assist->r0;
 
 	// If A1, A2, and A3 are zero, skip.
 	if(A1==0. && A2==0. && A3==0.)
@@ -853,24 +866,6 @@ static void assist_additional_force_non_gravitational(struct reb_simulation* sim
         const double r2 = dx*dx + dy*dy + dz*dz;
         const double r = sqrt(r2);
 
-	// We may need to make this more general.
-	//const double g = 1.0/r2;
-
-	// Need to make these more flexible
-
-	// 'Oumuamua
-	//double alpha = 0.04083733261;
-	//double nk = 2.6;
-	//double nm = 2.0;
-	//double nn = 3.0;
-	//double r0 = 5.0;
-
-	// Standard --> r^-2
-	double alpha = 1.0;
-	double nk = 0.0;
-	double nm = 2.0;
-	double nn = 5.093;
-	double r0 = 1.0;
 	
 	const double g = alpha*pow(r/r0, -nm)*pow(1.0+pow(r/r0, nn), -nk);
 	//const double g = 1.0/r2;	


### PR DESCRIPTION
Offer ways to change non-gravitational parameters for the simulation. 

Python Usage: 

```python
sim = rebound.Simulation()
extras = assist.Extras(sim, ephem)
extras.alpha = 1.0
extras.nk = ...
```

Default behaviour and default values have not changed. This thus doesn't break any previous code.

No documentation added yet. 

Closes #112.